### PR TITLE
Support for markdown in docstrings in epythet

### DIFF
--- a/epythet/_static/docsrc/conf.py
+++ b/epythet/_static/docsrc/conf.py
@@ -37,6 +37,8 @@ extensions = [
     'sphinx.ext.todo',  # Support for todo items
     'sphinx.ext.viewcode',  # Add links to highlighted source code
     'myst_parser',  # Parse .md files
+    'sphinx_toggleprompt',
+    'sphinx_copybutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -72,3 +74,5 @@ def docstring(app, what, name, obj, options, lines):
 
 def setup(app):
     app.connect('autodoc-process-docstring', docstring)
+
+toggleprompt_offset_right = 25

--- a/epythet/_static/docsrc/conf.py
+++ b/epythet/_static/docsrc/conf.py
@@ -36,7 +36,7 @@ extensions = [
     'sphinx.ext.napoleon',  # Support for NumPy and Google style docstrings
     'sphinx.ext.todo',  # Support for todo items
     'sphinx.ext.viewcode',  # Add links to highlighted source code
-    'recommonmark',  # Parse .md files
+    'myst_parser',  # Parse .md files
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -58,3 +58,17 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+
+# -- Options for Markdown support -------------------------------------------
+import commonmark
+
+def docstring(app, what, name, obj, options, lines):
+    md  = '\n'.join(lines)
+    ast = commonmark.Parser().parse(md)
+    rst = commonmark.ReStructuredTextRenderer().render(ast)
+    lines.clear()
+    lines += rst.splitlines()
+
+def setup(app):
+    app.connect('autodoc-process-docstring', docstring)

--- a/epythet/_static/docsrc/conf.py
+++ b/epythet/_static/docsrc/conf.py
@@ -30,7 +30,7 @@ project, copyright, author, release, display_name = parse_config(
 # ones.
 extensions = [
     'sphinx_toggleprompt',
-    #'sphinx_copybutton',
+    'sphinx_copybutton',
     'sphinx.ext.autodoc',  # Include documentation from docstrings
     'sphinx.ext.doctest',  # Test snippets in the documentation
     'sphinx.ext.githubpages',  # This extension creates .nojekyll file

--- a/epythet/_static/docsrc/conf.py
+++ b/epythet/_static/docsrc/conf.py
@@ -29,6 +29,8 @@ project, copyright, author, release, display_name = parse_config(
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_toggleprompt',
+    #'sphinx_copybutton',
     'sphinx.ext.autodoc',  # Include documentation from docstrings
     'sphinx.ext.doctest',  # Test snippets in the documentation
     'sphinx.ext.githubpages',  # This extension creates .nojekyll file
@@ -36,9 +38,7 @@ extensions = [
     'sphinx.ext.napoleon',  # Support for NumPy and Google style docstrings
     'sphinx.ext.todo',  # Support for todo items
     'sphinx.ext.viewcode',  # Add links to highlighted source code
-    'myst_parser',  # Parse .md files
-    'sphinx_toggleprompt',
-    'sphinx_copybutton',
+    'myst_parser',  # Parse .md files    
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
 	Sphinx==3.3.1
 	commonmark
 	argh==0.26.2
+	sphinx-toggleprompt
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ include_package_data = True
 zip_safe = False
 install_requires =
 	Sphinx==3.3.1
-	recommonmark==0.6.0
+	commonmark
 	argh==0.26.2
 
 [options.entry_points]


### PR DESCRIPTION
- markdown support for dosctrings is proposed in this request: epythet can now pick markdown code blocks written in docstrings automatically with a result like in the pic below. 

- copy button for code blocks: support added
- toggle prompt for code blocks: does not work yet. solution found online works only for rst code blocks and not markdown unfortunately. Python docs and sklearn (who have a toggle and use sphinx) do it through some complicated js workaround, that I could not make work with epythet
![Screen Shot 2021-09-22 at 10 41 15](https://user-images.githubusercontent.com/17656072/134360260-00b09f11-cc26-49ea-a918-bc3ce270211b.png)
